### PR TITLE
Redirect after death

### DIFF
--- a/scripts/night/foxy.gd
+++ b/scripts/night/foxy.gd
@@ -118,4 +118,4 @@ func _on_button_increasestate_pressed():
 	state += 1
 
 func _on_sound_jump_finished():
-	get_tree().quit(666)
+        get_tree().change_scene_to_file("res://mainmenu.tscn")


### PR DESCRIPTION
## Summary
- redirect after being jumpscared to the main menu instead of quitting