### PR TITLE
Fix pause overlay visibility

### DIFF
--- a/scripts/pause/panel_container.gd
+++ b/scripts/pause/panel_container.gd
@@ -1,18 +1,21 @@
 extends Control
 
+onready var _root := get_parent()
+onready var _anim := _root.get_node("AnimationPlayer")
+
 func _ready():
-	hide()
-	$AnimationPlayer.play("RESET")
+        _root.hide()
+        _anim.play("RESET")
 
 func resume():
-	hide()
-	get_tree().paused = false
-	$AnimationPlayer.play_backwards("blur")
+        _root.hide()
+        get_tree().paused = false
+        _anim.play_backwards("blur")
 	
 func pause():
-	show()
-	get_tree().paused = true
-	$AnimationPlayer.play("blur")
+        _root.show()
+        get_tree().paused = true
+        _anim.play("blur")
 
 func testEsc():
 	if Input.is_action_just_pressed("esc") and !get_tree().paused:
@@ -24,7 +27,7 @@ func _on_continuar_pressed() -> void:
 	resume()
 
 func _on_sair_pressed() -> void:
-	pass # Replace with function body.
+        get_tree().change_scene_to_file("res://mainmenu.tscn")
 
 func _on_configuracoes_pressed() -> void:
 	get_tree().quit()


### PR DESCRIPTION
## Summary
- fix pause menu overlay staying visible after resuming
- hook up 'Sair' button to return to the main menu